### PR TITLE
modules: quickshell: Fix outdated name kde6

### DIFF
--- a/modules/quickshell.nix
+++ b/modules/quickshell.nix
@@ -13,7 +13,7 @@ in
     };
     qt = {
       enable = true;
-      platformTheme.name = "kde6";
+      platformTheme.name = "kde";
     };
     home.sessionVariables.ILLOGICAL_IMPULSE_VIRTUAL_ENV = "~/.local/state/quickshell/.venv";
 


### PR DESCRIPTION
Name 'kde6' is no longer valid in Nix. It was replaced with 'kde'. Warning in home build process:
> evaluation warning: The qt.platformTheme.name value "kde6" has been deprecated and renamed to "kde".

This condition prevents QuickShell from working:
> ERROR: caused by ... module "Qt5Compat.GraphicalEffects" is not installed

Fix by changing 'kde6' to 'kde'.